### PR TITLE
update missed type hint

### DIFF
--- a/scripts/dataset_tag_editor/dataset_tag_editor.py
+++ b/scripts/dataset_tag_editor/dataset_tag_editor.py
@@ -198,7 +198,7 @@ class DatasetTagEditor:
 
         print(f'Total {len(filepath_set)} files under the directory including not image files.')
 
-        def load_images(filepath_set: set[str]):
+        def load_images(filepath_set: Set[str]):
             for img_path in filepath_set:
                 img_dir = os.path.dirname(img_path)
                 img_filename, img_ext = os.path.splitext(os.path.basename(img_path))


### PR DESCRIPTION
This missed type hint was causing the load images to fail with a 'type' not subscriptable error.