### PR TITLE
Fix Z3D interrogator by passing missing Z3D threshold value

### DIFF
--- a/scripts/tag_editor_ui/block_load_dataset.py
+++ b/scripts/tag_editor_ui/block_load_dataset.py
@@ -199,6 +199,7 @@ class LoadDatasetUI(UIBase):
                 self.sl_custom_threshold_booru,
                 self.cb_use_custom_threshold_waifu,
                 self.sl_custom_threshold_waifu,
+                self.sl_custom_threshold_z3d,
                 toprow.cb_save_kohya_metadata,
                 toprow.tb_metadata_output,
             ],


### PR DESCRIPTION
Currently attempting to use the Z3D interrogator doesn't work because the threshold value isn't getting passed into the load_dataset function.  This fixes that.